### PR TITLE
Remove TFM from OutputPath

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
     <RepositoryUrl>https://github.com/cythral/identity-resources</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Configuration Condition="$(Configuration) == ''">Debug</Configuration>
@@ -14,7 +15,9 @@
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
+
   <PropertyGroup>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode>true</RestoreLockedMode>
@@ -24,6 +27,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
+
   <PropertyGroup>
     <BinaryLogger>$(MSBuildThisFileDirectory)obj\logs\$(OS).binlog</BinaryLogger>
     <OutputPath>$(MSBuildThisFileDirectory)bin/$(MSBuildProjectName)/$(Configuration)</OutputPath>
@@ -32,12 +36,15 @@
     <RestorePackagesPath>$(MSBuildThisFileDirectory).nuget</RestorePackagesPath>
     <CompilerGeneratedFilesOutputPath>$(MSBuildThisFileDirectory)obj\$(MSBuildProjectName)\$(Configuration)</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
+
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
   </ItemGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Visible="false" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333" PrivateAssets="all" />
   </ItemGroup>

--- a/deploy/identity-resources.template.yml
+++ b/deploy/identity-resources.template.yml
@@ -34,7 +34,7 @@ Resources:
       Handler: Brighid.Identity.Resources.Application::Brighid.Identity.Resources.Application.Handler::Run
       Runtime: provided.al2
       Timeout: 30
-      CodeUri: ../bin/Resources.Application/Release/net6.0/linux-x64/publish/
+      CodeUri: ../bin/Resources.Application/Release/linux-x64/publish/
       MemorySize: 512
       Policies:
         - !ImportValue cfn-utilities:SecretsKeyDecryptPolicyArn
@@ -57,7 +57,7 @@ Resources:
       Handler: Brighid.Identity.Resources.Role::Brighid.Identity.Resources.Role.Handler::Run
       Runtime: provided.al2
       Timeout: 30
-      CodeUri: ../bin/Resources.Role/Release/net6.0/linux-x64/publish/
+      CodeUri: ../bin/Resources.Role/Release/linux-x64/publish/
       MemorySize: 512
       Policies:
         - !ImportValue cfn-utilities:SecretsKeyDecryptPolicyArn


### PR DESCRIPTION
Removes the TFM from the OutputPath so the template doesn't have to be adjusted when the TFM changes.